### PR TITLE
[feat] create first two Review screens

### DIFF
--- a/avid-adventurers/src/App.tsx
+++ b/avid-adventurers/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Profile from './pages/onboarding/Profile';
 import Age from './pages/onboarding/Age';
 import Interests from './pages/onboarding/Interests';
+import Congrats from './pages/survey/Congrats';
+import Rate from './pages/survey/Rate';
 import { OnboardingProvider } from './utils/onboardingContext';
 import Events from './pages/onboarding/Events';
 
@@ -9,6 +11,8 @@ import TempHome from "./pages/TempHome";
 import TempBucket from "./pages/TempBucket";
 import TempChat from "./pages/TempChat";
 import TempProfile from "./pages/TempProfile";
+import { SurveyProvider } from './utils/surveyContext';
+
 
 function App() {
   return (
@@ -25,6 +29,12 @@ function App() {
           <Route path="/events" element={<Events />} />
         </Routes>
       </OnboardingProvider>
+      <SurveyProvider>
+        <Routes>
+          <Route path="/survey/congrats" element={<Congrats />} />
+          <Route path="/survey/rate" element={<Rate />} />
+        </Routes>
+      </SurveyProvider>
     </Router>
   );
 }

--- a/avid-adventurers/src/components/Label/Label.tsx
+++ b/avid-adventurers/src/components/Label/Label.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { StyledLabel, Wrapper } from './styles';
+import { ProfileImage} from '../../components/ProfileImage/ProfileImage';
+
+interface LabelProps {
+  label: string;
+  multiline?: boolean; 
+  image?: File | null;
+}
+
+export const Label: React.FC<LabelProps> = ({
+  label,
+  multiline = false, 
+  image = null,
+}) => {
+    return (
+        <Wrapper>
+            <StyledLabel>{label}</StyledLabel>
+            {image && <ProfileImage profileImage={image} />}
+        </Wrapper>
+        );
+    };

--- a/avid-adventurers/src/components/Label/styles.ts
+++ b/avid-adventurers/src/components/Label/styles.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  width: 100%;
+  max-width: 350px;
+  padding: 0.5rem;
+  border: 2px solid black;
+  border-radius: 0.5rem;
+  background-color: #f0f0f0;
+`;
+
+export const StyledLabel = styled.h1`
+  margin-bottom: 2rem;
+  color: #333;
+  text-align: center;
+`;

--- a/avid-adventurers/src/components/ProfileImage/ProfileImage.tsx
+++ b/avid-adventurers/src/components/ProfileImage/ProfileImage.tsx
@@ -9,7 +9,7 @@ import {
 
 interface ProfileImageUploadProps {
   profileImage: File | null;
-  setProfileImage: (file: File) => void;
+  setProfileImage?: (file: File) => void;
 }
 
 export const ProfileImage: React.FC<ProfileImageUploadProps> = ({
@@ -19,6 +19,7 @@ export const ProfileImage: React.FC<ProfileImageUploadProps> = ({
   const [imageError, setImageError] = useState(false);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!setProfileImage) return;
     if (e.target.files && e.target.files[0]) {
       setProfileImage(e.target.files[0]);
       setImageError(false);

--- a/avid-adventurers/src/components/Rating/Rating.tsx
+++ b/avid-adventurers/src/components/Rating/Rating.tsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react';
+import { StarWrapper, Star } from './styles';
+
+interface RatingProps {
+  initialRating?: number;
+  onRatingChange: (rating: number) => void;
+}
+
+const Rating: React.FC<RatingProps> = ({ initialRating = 0, onRatingChange }) => {
+  const [rating, setRating] = useState(initialRating);
+
+  useEffect(() => {
+    setRating(initialRating); 
+  }, [initialRating]);
+
+  const handleStarClick = (rating: number) => {
+    setRating(rating);
+    onRatingChange(rating);
+  };
+
+  return (
+    <StarWrapper>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <Star
+          key={star}
+          filled={star <= rating}
+          style={{ cursor: 'pointer', color: star <= rating ? 'gold' : 'gray' }}
+          onClick={() => handleStarClick(star)}
+        >
+          ★
+        </Star>
+      ))}
+    </StarWrapper>
+  );
+};
+
+export default Rating;

--- a/avid-adventurers/src/components/Rating/styles.ts
+++ b/avid-adventurers/src/components/Rating/styles.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const StarWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 1rem;
+`;
+
+export const Star = styled.span<{ filled: boolean }>`
+  font-size: 2rem;
+  cursor: pointer;
+  color: ${(props) => (props.filled ? '#FFD700' : '#ccc')}; /* Gold color for filled stars */
+`;
+
+export {};

--- a/avid-adventurers/src/pages/styles.ts
+++ b/avid-adventurers/src/pages/styles.ts
@@ -121,3 +121,13 @@ export const ContinueButton = styled.button`
     color: #000000;
   }
 `;
+
+export const BackgroundWrapper = styled.div`
+  background-image: url('https://cdn.pixabay.com/animation/2024/05/02/07/43/07-43-00-535_512.gif');
+  background-size: cover;
+  background-position: center center;
+  background-attachment: fixed;
+  background-repeat: no-repeat;
+  height: 100vh;
+  z-index: -1;
+`;

--- a/avid-adventurers/src/pages/survey/Congrats.tsx
+++ b/avid-adventurers/src/pages/survey/Congrats.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Label } from '../../components/Label/Label';
+import { Container, Title, FormWrapper, ButtonRow, BackButton, ContinueButton } from '../styles';
+import { useSurvey } from '../../utils/surveyContext';
+
+
+const Congrats: React.FC = () => {
+    const navigate = useNavigate();
+    const { friendProfileImage, friendName, friendInterests, activity, interests, rating, setRating, updateInterests, setProfileImage } = useSurvey();
+
+    const handleContinue = () => {
+      navigate('/survey/rate');
+    };
+
+    const pageStyle = {
+        backgroundImage: "url('https://cdn.pixabay.com/animation/2024/05/02/07/43/07-43-00-535_512.gif')",
+        backgroundSize: 'cover',
+        backgroundPosition: 'center center',
+        backgroundAttachment: 'fixed',
+        backgroundRepeat: 'no-repeat !important',
+        height: '100vh', 
+        zIndex: '-1',
+    };
+
+    return (
+    <div style={pageStyle}>
+        <Container>
+        <FormWrapper>
+            <Label
+                    label={`You met ${friendName} for ${activity}!`}
+                    multiline = {true}
+                    image = {friendProfileImage}
+                    />
+            <ButtonRow> 
+                <ContinueButton onClick={handleContinue}>Continue</ContinueButton>
+            </ButtonRow>
+        </FormWrapper>
+        </Container>
+    </div>
+)};
+
+export default Congrats;

--- a/avid-adventurers/src/pages/survey/Congrats.tsx
+++ b/avid-adventurers/src/pages/survey/Congrats.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Label } from '../../components/Label/Label';
-import { Container, Title, FormWrapper, ButtonRow, BackButton, ContinueButton } from '../styles';
+import { BackgroundWrapper, Container, FormWrapper, ButtonRow, ContinueButton } from '../styles';
 import { useSurvey } from '../../utils/surveyContext';
 
 
@@ -13,18 +13,8 @@ const Congrats: React.FC = () => {
       navigate('/survey/rate');
     };
 
-    const pageStyle = {
-        backgroundImage: "url('https://cdn.pixabay.com/animation/2024/05/02/07/43/07-43-00-535_512.gif')",
-        backgroundSize: 'cover',
-        backgroundPosition: 'center center',
-        backgroundAttachment: 'fixed',
-        backgroundRepeat: 'no-repeat !important',
-        height: '100vh', 
-        zIndex: '-1',
-    };
-
     return (
-    <div style={pageStyle}>
+    <BackgroundWrapper>
         <Container>
         <FormWrapper>
             <Label
@@ -37,7 +27,7 @@ const Congrats: React.FC = () => {
             </ButtonRow>
         </FormWrapper>
         </Container>
-    </div>
+    </BackgroundWrapper>
 )};
 
 export default Congrats;

--- a/avid-adventurers/src/pages/survey/Rate.tsx
+++ b/avid-adventurers/src/pages/survey/Rate.tsx
@@ -1,41 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Label } from '../../components/Label/Label';
 import Rating from '../../components/Rating/Rating';
-import { Container, Title, FormWrapper, ButtonRow, BackButton, ContinueButton } from '../styles';
+import { Container, FormWrapper, ButtonRow, BackButton, ContinueButton } from '../styles';
 import { useSurvey } from '../../utils/surveyContext';
 import { LabeledInput } from '../../components/LabeledInput/LabeledInput';
 
 
 const Rate: React.FC = () => {
     const navigate = useNavigate();
-    const [rating, setRating] = useState(0);
-    const [experience, setExperience] = useState('');
-
-    useEffect(() => {
-      const savedRating = localStorage.getItem('rating');
-      const savedExperience = localStorage.getItem('experience');
-      
-      if (savedRating) {
-        setRating(Number(savedRating));
-      }
-      
-      if (savedExperience) {
-        setExperience(savedExperience); 
-      }
-    }, []);
-
-    useEffect(() => {
-      if (rating) {
-        localStorage.setItem('rating', rating.toString()); 
-      }
-    }, [rating]); 
-
-    useEffect(() => {
-      if (experience) {
-        localStorage.setItem('experience', experience); 
-      }
-    }, [experience]);
+    const { rating, setRating, experience, setExperience } = useSurvey();
 
     const handleContinue = () => {
       navigate('/survey/rated');

--- a/avid-adventurers/src/pages/survey/Rate.tsx
+++ b/avid-adventurers/src/pages/survey/Rate.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Label } from '../../components/Label/Label';
+import Rating from '../../components/Rating/Rating';
+import { Container, Title, FormWrapper, ButtonRow, BackButton, ContinueButton } from '../styles';
+import { useSurvey } from '../../utils/surveyContext';
+import { LabeledInput } from '../../components/LabeledInput/LabeledInput';
+
+
+const Rate: React.FC = () => {
+    const navigate = useNavigate();
+    const [rating, setRating] = useState(0);
+    const [experience, setExperience] = useState('');
+
+    useEffect(() => {
+      const savedRating = localStorage.getItem('rating');
+      const savedExperience = localStorage.getItem('experience');
+      
+      if (savedRating) {
+        setRating(Number(savedRating));
+      }
+      
+      if (savedExperience) {
+        setExperience(savedExperience); 
+      }
+    }, []);
+
+    useEffect(() => {
+      if (rating) {
+        localStorage.setItem('rating', rating.toString()); 
+      }
+    }, [rating]); 
+
+    useEffect(() => {
+      if (experience) {
+        localStorage.setItem('experience', experience); 
+      }
+    }, [experience]);
+
+    const handleContinue = () => {
+      navigate('/survey/rated');
+    };
+
+    const handleBack = () => {
+      navigate('/survey/congrats');
+    }
+
+    const handleRatingChange = (newRating: number) => {
+      setRating(newRating); // Update the rating state when the user clicks a star
+    };
+
+    return (
+    <Container>
+      <FormWrapper>
+        <Label
+          label = "How did you like the experience?"
+        />
+        {/* Rating component */}
+        <Rating initialRating={rating} onRatingChange={handleRatingChange} />
+        <LabeledInput
+          label="Why?"
+          placeholder="Type your thoughts here..."
+          value={experience}
+          multiline={true}
+          onChange={(e) => setExperience(e.target.value)}
+        />
+        <ButtonRow>
+          <BackButton onClick={handleBack}>Back</BackButton> 
+          <ContinueButton onClick={handleContinue}>Continue</ContinueButton>
+        </ButtonRow>
+      </FormWrapper>
+    </Container>
+    );
+  };
+  
+  export default Rate;

--- a/avid-adventurers/src/utils/surveyContext.tsx
+++ b/avid-adventurers/src/utils/surveyContext.tsx
@@ -8,6 +8,8 @@ interface SurveyData {
   activity: string;
   rating: number;
   setRating: (rating: number) => void;
+  experience: string;
+  setExperience: (experience: string) => void;
   updateInterests: (interests: string[]) => void;
   setProfileImage: (file: File | null) => void;
 }
@@ -29,6 +31,7 @@ export const SurveyProvider = ({ children }: { children: ReactNode }) => {
     const [interests, setInterests] = useState<string[]>(['paddleboarding', 'skateboarding', 'sailing', 'hiking', 'coffee', 'wine tasting', 'concerts']); // current user's interests
     const activity = 'skateboarding';
     const [rating, setRating] = useState<number>(0);
+    const [experience, setExperience] = useState<string>('');
   
     const updateInterests = (newInterests: string[]) => {
       setInterests((prev) => Array.from(new Set([...prev, ...newInterests])));
@@ -44,6 +47,8 @@ export const SurveyProvider = ({ children }: { children: ReactNode }) => {
           activity,
           rating,
           setRating,
+          experience,
+          setExperience,
           updateInterests,
           setProfileImage,
         }}

--- a/avid-adventurers/src/utils/surveyContext.tsx
+++ b/avid-adventurers/src/utils/surveyContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface SurveyData {
+  friendProfileImage: File | null;
+  friendName: string;
+  friendInterests: string[];
+  interests: string[];
+  activity: string;
+  rating: number;
+  setRating: (rating: number) => void;
+  updateInterests: (interests: string[]) => void;
+  setProfileImage: (file: File | null) => void;
+}
+
+const SurveyContext = createContext<SurveyData | undefined>(undefined);
+
+export const useSurvey = () => {
+  const context = useContext(SurveyContext);
+  if (!context) {
+    throw new Error('useSurvey must be used within a SurveyProvider');
+  }
+  return context;
+};
+
+export const SurveyProvider = ({ children }: { children: ReactNode }) => {
+    const [friendProfileImage, setProfileImage] = useState<File | null>(null);
+    const friendName = 'Tyler';
+    const friendInterests = ['skateboarding', 'hiking', 'sailing'];
+    const [interests, setInterests] = useState<string[]>(['paddleboarding', 'skateboarding', 'sailing', 'hiking', 'coffee', 'wine tasting', 'concerts']); // current user's interests
+    const activity = 'skateboarding';
+    const [rating, setRating] = useState<number>(0);
+  
+    const updateInterests = (newInterests: string[]) => {
+      setInterests((prev) => Array.from(new Set([...prev, ...newInterests])));
+    };
+  
+    return (
+      <SurveyContext.Provider
+        value={{
+          friendProfileImage,
+          friendName,
+          friendInterests,
+          interests,
+          activity,
+          rating,
+          setRating,
+          updateInterests,
+          setProfileImage,
+        }}
+      >
+        {children}
+      </SurveyContext.Provider>
+    );
+  };


### PR DESCRIPTION
Created a page /survey/congrats for the "You met [friend's name]!", with a confetti background, and a page /survey/rate that lets the user give the experience a rating on a 5-star scale and explain why they feel that way in a text box. The rating and explanation persist on page reload. (Only created new files, but edited 1 line in ProfileImage component to turn off the ability to upload a new photo.)
![Screen Shot 2025-04-17 at 12 27 37 PM](https://github.com/user-attachments/assets/49c1188e-57a6-481f-b6a3-019959d21752)
![Screen Shot 2025-04-17 at 12 27 53 PM](https://github.com/user-attachments/assets/b056fd8e-fa05-4021-b3b6-d7571d97b92b)

